### PR TITLE
REL-9958: Fix documentation inconsistencies in ldsk-dynamic-samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides tools and examples to help you create and optimize dyna
 
 ## Overview
 
-LDSK is a powerful digital signage platform that enables you to deliver engaging, dynamic content to your audience. This kit focuses on two key aspects of developing for LDSK:
+LDSK is a powerful digital signage platform that enables you to deliver engaging, dynamic content to your audience. This kit provides three worked examples — from a basic creative, to player-side media caching, to fully delegated native playback (recommended for Samsung Tizen).
 
 In a high level view this is the sequence of events that happen when a creative is loaded in the LDSK player:
 
@@ -21,18 +21,22 @@ sequenceDiagram
 
 ## Repository Structure
 
-* **basic-workflow:** A simple HTML5 creative that demonstrates the core structure and postMessage communication with the LDSK player.
-* **optimized-with-caching:** An enhanced creative showcasing how to request and use cached media assets (images, videos) for faster loading and reduced bandwidth usage.
+* **basic-workflow:** A simple HTML5 creative that demonstrates the core structure and postMessage communication with the LDSK player (`PLAYER_CONFIGURATION`, `PLAY`).
+* **optimized-with-caching:** An enhanced creative showcasing how to request and use cached media assets (images, videos) via `MEDIA_REQUEST` / `MEDIA_RESPONSE` for faster loading and reduced bandwidth usage.
+* **delegated-playback:** A creative that delegates media playback to the native LDSK player using `DELEGATE_PLAY`. **Recommended for Samsung Tizen screens**, as it avoids multiple `<video>` element conflicts and lets the player manage caching and playback natively.
 
 ## Getting Started
 
-1. **Clone the Repository:** \
-   Bash \
-   git clone https://github.com/livedooh-Git/ldsk-dynamic-samples.git \
+1. **Clone the Repository:**
+
+   ```bash
+   git clone https://github.com/livedooh-Git/ldsk-dynamic-samples.git
+   ```
 
 2. **Explore the Examples:**
-    * **basic-workflow:** Understand the basic structure of an HTML5 creative and how to interact with LDSK events (PLAYER_CONFIGURATION, PLAY).
-    * **optimized-with-caching:** Learn how to send MEDIA_REQUEST messages and handle MEDIA_RESPONSE events to utilize cached media.
+    * **basic-workflow:** Understand the basic structure of an HTML5 creative and how to interact with LDSK events (`PLAYER_CONFIGURATION`, `PLAY`).
+    * **optimized-with-caching:** Learn how to send `MEDIA_REQUEST` messages and handle `MEDIA_RESPONSE` events to utilize cached media.
+    * **delegated-playback:** Learn how to hand media playback to the native player with `DELEGATE_PLAY` — the recommended approach for Tizen.
 3. **Adapt and Create:**
     * Use the examples as templates to build your own creatives.
     * Customize the content, styling, and interactivity to suit your campaign goals.
@@ -45,29 +49,30 @@ sequenceDiagram
 * **postMessage API:** The primary way your creative communicates with the LDSK player.
 * **PLAYER_CONFIGURATION Event:** Provides inventory data about the screen (e.g., location, attributes) for dynamic content personalization.
 * **PLAY Event:** Signals the exact moment to start your creative's playback.
-* **MEDIA_REQUEST, MEDIA_RESPONSE, and MEDIA_REQUEST_EXCEPTION Events:** Enable media caching and efficient loading.
+* **MEDIA_REQUEST, MEDIA_RESPONSE, and MEDIA_REQUEST_EXCEPTION Events:** Enable media caching and efficient loading. See [optimized-with-caching](./optimized-with-caching/readme.md).
+* **DELEGATE_PLAY and DELEGATE_PLAY_RESPONSE Events:** Delegate media playback to the native player instead of rendering it in the creative. Recommended for Samsung Tizen. See [delegated-playback](./delegated-playback/README.md).
 
 ## **Packaging Your Creative**
 
 Before deploying your HTML5 creative to LDSK, you need to package it into a ZIP archive:
 
 1. **Gather Your Assets:**
-   * **<code>index.html</code>:</strong> Your main HTML file.
-   * <strong>Other HTML files (if any):</strong> Any additional HTML files used by your creative.
-   * <strong>JavaScript files (.js):</strong> Your creative's logic and interactivity.
-   * <strong>CSS files (.css):</strong> Styles for your creative.
-   * <strong>Images (.jpg, .png, etc.):</strong> Visual assets.
-   * <strong>Videos (.mp4):</strong> Video content.
-   * <strong>Other assets (fonts, etc.):</strong> Any other files required by your creative.
-2. <strong>Create the ZIP Archive:</strong>
+   * **`index.html`:** Your main HTML file.
+   * **Other HTML files (if any):** Any additional HTML files used by your creative.
+   * **JavaScript files (`.js`):** Your creative's logic and interactivity.
+   * **CSS files (`.css`):** Styles for your creative.
+   * **Images (`.jpg`, `.png`, etc.):** Visual assets.
+   * **Videos (`.mp4`):** Video content.
+   * **Other assets (fonts, etc.):** Any other files required by your creative.
+2. **Create the ZIP Archive:**
    * Create a new folder to hold your creative.
    * Place all of your creative's assets inside this folder.
    * Select all the files and folders within the creative folder.
    * Right-click and choose "Compress" (or similar option) to create a ZIP archive.
-3. <strong>Important Considerations:</strong>
-   * <strong>Root Level <code>index.html</code>:</strong> Make sure your <code>index.html</code> file is at the root level of the ZIP archive (not inside a subfolder).
-   * <strong>No Nested ZIPs:</strong> Do not include other ZIP archives within your creative's ZIP file.
-   * <strong>Relative Paths:</strong> Ensure that all file paths within your creative (e.g., references to images or videos) are relative to the <code>index.html</code> file.
+3. **Important Considerations:**
+   * **Root Level `index.html`:** Make sure your `index.html` file is at the root level of the ZIP archive (not inside a subfolder).
+   * **No Nested ZIPs:** Do not include other ZIP archives within your creative's ZIP file.
+   * **Relative Paths:** Ensure that all file paths within your creative (e.g., references to images or videos) are relative to the `index.html` file.
 
 
 
@@ -85,7 +90,7 @@ the Samsung Tizen screens struggle when more than one `<video>` element tag pres
 behind the scenes, it is very possible that another `<video>` element tag is presently playing. This will cause the screen
  to blank into a black frame and the creative will not play.
 
-### How to Run the Examples
+## How to Run the Examples
 
 1. change to corresponding directory.
 2. run `npm install` to install the dependencies.

--- a/basic-workflow/readme.md
+++ b/basic-workflow/readme.md
@@ -2,11 +2,11 @@
 This example demonstrates the basic workflow for a dynamic creative in the LDSK player.
 The example is a simple creative that displays a single video after evaluating attributes on the inventory context provided by the player.
 
-## Events: PLAY_CONFIGURATION and PLAY
+## Events: PLAYER_CONFIGURATION and PLAY
 
 The LDSK player communicates with your HTML5 creative through two important events:
 
-### 1. PLAY_CONFIGURATION Event
+### 1. PLAYER_CONFIGURATION Event
 
 * **When:** Sent **5 seconds before** your creative starts playing.
 * **Why:** Gives you a heads-up so you can prepare your creative for a smooth start.

--- a/delegated-playback/README.md
+++ b/delegated-playback/README.md
@@ -335,7 +335,7 @@ The DELEGATE_PLAY pattern is a powerful way to optimize media playback in LDSK c
 **Key Takeaways:**
 1. Send `DELEGATE_PLAY` after receiving `PLAYER_CONFIGURATION`
 2. Always handle the `DELEGATE_PLAY_RESPONSE` for confirmation
-3. Hide your creative (opacity: 0) when delegating playback
+3. Do **not** hide the creative manually — the player automatically hides it when it takes over playback. Only manage `opacity` in the video-element fallback path (set `opacity: 1` to show the creative when delegation fails)
 4. Use `placeholders.json` and `placeholders.js` for media URLs
 5. Implement video element fallback for error scenarios
 6. Test thoroughly with the included `player.html` simulator

--- a/optimized-with-caching/readme.md
+++ b/optimized-with-caching/readme.md
@@ -59,16 +59,17 @@ sequenceDiagram
 JavaScript
 
 ```javascript
-var img = new Image();
-img.onload = function() { /* handle successful load */ };
-img.onerror = function() {
-    parent.postMessage({
-        type: 'MEDIA_REQUEST',
-        requestId: 'image123', 
-        url: this.src
-    }, '*');
-};
-img.src = 'https://example.com/images/my-image.jpg';
+// The media details go inside a `payload` object, and the player reads them
+// as `event.data.payload.*`. Use `mediaUrl` (not `url`) and include `mediaType`.
+parent.postMessage({
+    type: 'MEDIA_REQUEST',
+    eventType: 'MEDIA_REQUEST',
+    payload: {
+        mediaType: 'image',
+        mediaUrl: 'https://example.com/images/my-image.jpg',
+        requestId: 'image123'
+    }
+}, '*');
 ```
 
 


### PR DESCRIPTION
## Summary

Documentation review of the HTML5 Creative Development Kit from the perspective of a Tizen developer (caching and smooth playback prioritized). Fixes inconsistencies between the docs and the actual code/simulators, one internal contradiction, and structural gaps. **Docs-only — no source or behavioral changes.**

Jira: [REL-9958](https://ldsk.atlassian.net/browse/REL-9958)

## Changes

- **README:** surface the `delegated-playback` example (recommended for Tizen) in Repository Structure, Getting Started, and Key Concepts — it was previously missing from all three. Fix the malformed clone step, the broken HTML in the Packaging section, and a misleveled "How to Run" heading.
- **basic-workflow:** rename `PLAY_CONFIGURATION` → `PLAYER_CONFIGURATION` to match the code, simulator, and JSON example.
- **optimized-with-caching:** fix the `MEDIA_REQUEST` JS example to use the `payload` wrapper with `mediaUrl`/`mediaType`, matching `main.js` and the simulator (which reads `event.data.payload.*`).
- **delegated-playback:** correct the Summary "Key Takeaway" that contradicted the doc's own guidance about the player auto-hiding the creative.

## Follow-up (out of scope, tracked in REL-9958)

`optimized-with-caching/main.js` builds its `MEDIA_REQUEST` without the `uuid` field despite its own comment/schema saying `uuid` is required — likely a code bug, to be confirmed and fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[REL-9958]: https://ldsk.atlassian.net/browse/REL-9958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ